### PR TITLE
Fix a URL bug

### DIFF
--- a/hw2/README.md
+++ b/hw2/README.md
@@ -14,7 +14,7 @@ Lastly, there is a lot of code in this directory. Please look [here](https://git
 
 # Spark
 
-Spark is an open-source distributed computing system written in [Scala](http://www.scala-lang.org). The project was started by Ph.D. students from our very own [AMPLab](amplab.cs.berkeley.edu) and is an integral part of the [Berkeley Data Analytics Stack](https://amplab.cs.berkeley.edu/software/) (BDAS—affectionately pronounced "bad-ass").
+Spark is an open-source distributed computing system written in [Scala](http://www.scala-lang.org). The project was started by Ph.D. students from our very own [AMPLab](https://amplab.cs.berkeley.edu) and is an integral part of the [Berkeley Data Analytics Stack](https://amplab.cs.berkeley.edu/software/) (BDAS—affectionately pronounced "bad-ass").
 
 Like Hadoop MapReduce, Spark is designed to run functions over large collections of data, by supporting a simplified set of high-level data processing operations akin to the iterators we've been learning about in class. One of the most common uses of such systems is to implement parallel query processing in high level languages such as SQL. In fact, many recent research and development efforts in Spark have gone towards supporting a scalable and interactive relational database abstraction.
 


### PR DESCRIPTION
The link of AMPLab is pointed to
https://github.com/cs186-spring15/course/blob/master/hw2/amplab.cs.berkeley.edu

which is wrong, it should be https://amplab.cs.berkeley.edu